### PR TITLE
Updates to symbol location feature branch

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   clang_format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
       - name: Run clang format
         run: |
           sudo apt update
-          sudo apt install -y git clang-format
+          sudo apt install -y git clang-format-14
           if [ $? -ge 1 ]; then return 1; fi
           ./.run-clang-format
           if [ $? -ge 1 ]; then return 1; fi

--- a/.run-clang-format
+++ b/.run-clang-format
@@ -1,2 +1,2 @@
 #!/bin/bash
-find . -type f -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hxx\)' -exec clang-format-8 -style=file -i {} \;
+find . -type f -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hxx\)' -exec clang-format-14 -style=file -i {} \;

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -240,7 +240,7 @@ std::vector<std::string> PluginLoader::getAvailablePlugins(const std::string& se
   std::vector<std::string> plugins;
   for (const auto& lib : libraries)
   {
-    std::vector<std::string> lib_plugins = getAllAvailableSymbols(section, lib);
+    std::vector<std::string> lib_plugins = getAllAvailableSymbols(lib, section);
     plugins.insert(plugins.end(), lib_plugins.begin(), lib_plugins.end());
   }
 

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -68,6 +68,7 @@ static std::shared_ptr<ClassBase> createSharedInstance(const std::string& symbol
  * @param search_paths_local list of local search paths in which to look for plugin libraries
  * @param search_system_folders flag indicating whether to look for plugins in system level folders
  * @return list of libraries with the specified input names that could be found in the specified input directories.
+ * Libraries specified with absolute paths will be returned first in the list before libraries found in local paths (but in no particular order in at the front of the list).
  */
 static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std::string>& library_names,
                                                              const std::set<std::string>& search_paths_local,
@@ -89,7 +90,8 @@ static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std:
         // If the library exists, add it to the output list and continue to the next library name
         if (lib.has_value())
         {
-          libraries.push_back(lib.value());
+          // Libraries specified as absolute paths should appear first in the output list, so insert them at the front of the list
+          libraries.insert(libraries.begin(), lib.value());
           continue;
         }
       }

--- a/include/boost_plugin_loader/plugin_loader.hpp
+++ b/include/boost_plugin_loader/plugin_loader.hpp
@@ -44,7 +44,8 @@ namespace boost_plugin_loader
  * @return A shared pointer of the object with the symbol name located in library_name_
  */
 template <class ClassBase>
-static std::shared_ptr<ClassBase> createSharedInstance(const std::string& symbol_name, const boost::dll::shared_library& lib)
+static std::shared_ptr<ClassBase> createSharedInstance(const std::string& symbol_name,
+                                                       const boost::dll::shared_library& lib)
 {
   // Check if library has symbol
   if (!lib.has(symbol_name))
@@ -54,7 +55,7 @@ static std::shared_ptr<ClassBase> createSharedInstance(const std::string& symbol
 #if BOOST_VERSION >= 107600
   boost::shared_ptr<ClassBase> plugin = boost::dll::import_symbol<ClassBase>(lib, symbol_name);
 #else
-  boost::shared_ptr<ClassBase> plugin = boost::dll::import<ClassBase>(lib, symbol_name);
+  boost::shared_ptr<ClassBase> plugin = boost::dll::import <ClassBase>(lib, symbol_name);
 #endif
   return std::shared_ptr<ClassBase>(plugin.get(), [plugin](ClassBase*) mutable { plugin.reset(); });
 }
@@ -62,13 +63,15 @@ static std::shared_ptr<ClassBase> createSharedInstance(const std::string& symbol
 /**
  * @brief Loads all libraries
  * @details This function first attempts to load the libraries specified as complete, absolute paths.
- * If the provided library name is not an absolute path, then this function searches for the library in each of the provided local search paths.
- * If the provided library name is not an absolute path and does not exist in the local search paths, then this function optionally searches for the library in system directories.
+ * If the provided library name is not an absolute path, then this function searches for the library in each of the
+ * provided local search paths. If the provided library name is not an absolute path and does not exist in the local
+ * search paths, then this function optionally searches for the library in system directories.
  * @param library_names list of library names
  * @param search_paths_local list of local search paths in which to look for plugin libraries
  * @param search_system_folders flag indicating whether to look for plugins in system level folders
  * @return list of libraries with the specified input names that could be found in the specified input directories.
- * Libraries specified with absolute paths will be returned first in the list before libraries found in local paths (but in no particular order in at the front of the list).
+ * Libraries specified with absolute paths will be returned first in the list before libraries found in local paths (but
+ * in no particular order in at the front of the list).
  */
 static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std::string>& library_names,
                                                              const std::set<std::string>& search_paths_local,
@@ -90,14 +93,16 @@ static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std:
         // If the library exists, add it to the output list and continue to the next library name
         if (lib.has_value())
         {
-          // Libraries specified as absolute paths should appear first in the output list, so insert them at the front of the list
+          // Libraries specified as absolute paths should appear first in the output list, so insert them at the front
+          // of the list
           libraries.insert(libraries.begin(), lib.value());
           continue;
         }
       }
     }
 
-    // If the library name is not an absolute path, try finding the library at the path defined as the combination of each local search path and the library name
+    // If the library name is not an absolute path, try finding the library at the path defined as the combination of
+    // each local search path and the library name
     std::optional<boost::dll::shared_library> lib = std::nullopt;
     for (const std::string& search_path : search_paths_local)
     {
@@ -112,7 +117,8 @@ static std::vector<boost::dll::shared_library> loadLibraries(const std::set<std:
       }
     }
 
-    // If the library cannot be found in any of the local search paths, search in the system level directories for the library (if enabled)
+    // If the library cannot be found in any of the local search paths, search in the system level directories for the
+    // library (if enabled)
     if (lib == std::nullopt && search_system_folders)
     {
       lib = loadLibrary(library_name);
@@ -181,12 +187,13 @@ std::shared_ptr<PluginBase> PluginLoader::createInstance(const std::string& plug
   const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
-  std::vector<boost::dll::shared_library> libraries = loadLibraries(library_names, search_paths_local, search_system_folders);
+  std::vector<boost::dll::shared_library> libraries =
+      loadLibraries(library_names, search_paths_local, search_system_folders);
 
   // Create an instance of the plugin
   for (const auto& lib : libraries)
   {
-    if(lib.has(plugin_name))
+    if (lib.has(plugin_name))
       return createSharedInstance<PluginBase>(plugin_name, lib);
   }
 
@@ -206,12 +213,13 @@ bool PluginLoader::isPluginAvailable(const std::string& plugin_name) const
   const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
-  std::vector<boost::dll::shared_library> libraries = loadLibraries(library_names, search_paths_local, search_system_folders);
+  std::vector<boost::dll::shared_library> libraries =
+      loadLibraries(library_names, search_paths_local, search_system_folders);
 
   // Check for the symbol name
   for (const auto& lib : libraries)
   {
-    if(lib.has(plugin_name))
+    if (lib.has(plugin_name))
       return true;
   }
 
@@ -236,7 +244,8 @@ std::vector<std::string> PluginLoader::getAvailablePlugins(const std::string& se
   const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
-  std::vector<boost::dll::shared_library> libraries = loadLibraries(library_names, search_paths_local, search_system_folders);
+  std::vector<boost::dll::shared_library> libraries =
+      loadLibraries(library_names, search_paths_local, search_system_folders);
 
   // Populate the list of plugins
   std::vector<std::string> plugins;
@@ -260,7 +269,8 @@ std::vector<std::string> PluginLoader::getAvailableSections(bool include_hidden)
   const std::set<std::string> search_paths_local = getAllSearchPaths(search_paths_env, search_paths);
 
   // Load the libraries
-  std::vector<boost::dll::shared_library> libraries = loadLibraries(library_names, search_paths_local, search_system_folders);
+  std::vector<boost::dll::shared_library> libraries =
+      loadLibraries(library_names, search_paths_local, search_system_folders);
 
   // Populate the list of sections
   std::vector<std::string> sections;

--- a/include/boost_plugin_loader/utils.h
+++ b/include/boost_plugin_loader/utils.h
@@ -38,56 +38,12 @@ public:
 };
 
 /**
- * @brief Load library give library name and directory
- * @param library_name The library name to load which does not include the prefix 'lib' or suffix '.so'
- * @param library_directory The library directory, if empty it will enable search system directories
- * @throws If library fails to load
- * @return A shared library
- */
-boost::dll::shared_library loadLibrary(const std::string& library_name, const std::string& library_directory = "");
-
-/**
  * @brief Attempt to load library give library name and directory
  * @param library_name The library name to load which does not include the prefix 'lib' or suffix '.so'
  * @param library_directory The library directory, if empty it will enable search system directories
  * @return A shared library
  */
-std::optional<boost::dll::shared_library> tryLoadLibrary(const std::string& library_name,
-                                                         const std::string& library_directory = "");
-
-/**
- * @brief Check if the symbol is available in the library_name searching system folders for library
- * @details The symbol name is the alias provide when calling EXPORT_CLASS_SECTIONED
- * @param symbol_name The symbol to create a shared instance of
- * @param library_name The library name to load which does not include the prefix 'lib' or suffix '.so'
- * @param library_directory The library directory, if empty it will enable search system directories
- * @return True if the symbol exists, otherwise false
- */
-bool isSymbolAvailable(const std::string& symbol_name, const std::string& library_name,
-                       const std::string& library_directory = "");
-
-/**
- * @brief Get a list of available symbols under the provided section
- * @param section The section to search for available symbols
- * @param library_name The library name to load which does not include the prefix 'lib' or suffix '.so'
- * @param library_directory The library directory, if empty it will enable search system directories
- * @throws If library fails to be found or load
- * @return A list of symbols if they exist.
- */
-[[deprecated]] std::vector<std::string> getAllAvailableSymbols(const std::string& section,
-                                                               const std::string& library_name,
-                                                               const std::string& library_directory = "");
-
-/**
- * @brief Get a list of available sections
- * @param library_name The library name to load which does not include the prefix 'lib' or suffix '.so'
- * @param library_directory The library directory, if empty it will enable search system directories
- * @throws If library fails to be found or load
- * @return A list of sections if they exist.
- */
-[[deprecated]] std::vector<std::string> getAllAvailableSections(const std::string& library_name,
-                                                                const std::string& library_directory = "",
-                                                                bool include_hidden = false);
+std::optional<boost::dll::shared_library> loadLibrary(const boost::filesystem::path& library_path);
 
 /**
  * @brief Get a list of available symbols under the provided section

--- a/include/boost_plugin_loader/utils.h
+++ b/include/boost_plugin_loader/utils.h
@@ -47,11 +47,11 @@ std::optional<boost::dll::shared_library> loadLibrary(const boost::filesystem::p
 
 /**
  * @brief Get a list of available symbols under the provided section
- * @param section The section to search for available symbols
  * @param library The library to search for available symbols
+ * @param section The section to search for available symbols
  * @return A list of symbols if they exist.
  */
-std::vector<std::string> getAllAvailableSymbols(const std::string& section, const boost::dll::shared_library& library);
+std::vector<std::string> getAllAvailableSymbols(const boost::dll::shared_library& library, const std::string& section);
 
 /**
  * @brief Get a list of available sections

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -62,7 +62,7 @@ std::optional<boost::dll::shared_library> loadLibrary(const boost::filesystem::p
   return lib;
 }
 
-std::vector<std::string> getAllAvailableSymbols(const std::string& section, const boost::dll::shared_library& library)
+std::vector<std::string> getAllAvailableSymbols(const boost::dll::shared_library& library, const std::string& section)
 {
   // Class `library_info` can extract information from a library
   boost::dll::library_info inf(library.location());

--- a/test/plugin_loader_unit.cpp
+++ b/test/plugin_loader_unit.cpp
@@ -126,7 +126,7 @@ TEST(BoostPluginLoaderUnit, Utils)  // NOLINT
   }
 
   {
-    std::vector<std::string> symbols = getAllAvailableSymbols("TestBase", lib.value());  // NOLINT
+    std::vector<std::string> symbols = getAllAvailableSymbols(lib.value(), "TestBase");  // NOLINT
     EXPECT_EQ(symbols.size(), 1);
     EXPECT_EQ(symbols.at(0), symbol_name);
   }

--- a/test/plugin_loader_unit.cpp
+++ b/test/plugin_loader_unit.cpp
@@ -108,7 +108,8 @@ TEST(BoostPluginLoaderUnit, Utils)  // NOLINT
   }
 
   {
-    std::optional<boost::dll::shared_library> lib = loadLibrary(boost::filesystem::path("does_not_exist") / "does_not_exist");
+    std::optional<boost::dll::shared_library> lib = loadLibrary(boost::filesystem::path("does_not_exist") / "does_not_"
+                                                                                                            "exist");
     EXPECT_FALSE(lib.has_value());
   }
 


### PR DESCRIPTION
Here are my proposed updates to the symbol location feature branch. The biggest change is the creation of the function that loads all valid library paths; instead of copy-pasting this process into multiple functions (i.e., `isPluginAvailable`, `createInstance`, `getAvailablePlugins`), we can define it in one place and make those functions look simpler. 

I'm not worrying about backwards compatibility at this point since quite a few things have changed, so I removed the deprecated functions.

